### PR TITLE
flask-oracle: fix incorrect reference to an XE environment in hit_counter.py

### DIFF
--- a/flask-oracle/hit_counter.py
+++ b/flask-oracle/hit_counter.py
@@ -12,7 +12,7 @@ Before running, set these environment variables to connect to the database:
 
     PYTHON_USERNAME       - your DB username
     PYTHON_PASSWORD       - your DB password
-    PYTHON_CONNECTSTRING  - the connection string to the DB, e.g. "example.com/XEPDB1"
+    PYTHON_CONNECTSTRING  - the connection string to the database, e.g. "localhost/freepdb1"
 
 This code serves as an example for establishing DevOps practices. It is deliberately written poorly
 and should not be considered an example other than for the improvements that are going to be applied

--- a/flask-oracle/templates/index.html
+++ b/flask-oracle/templates/index.html
@@ -109,9 +109,10 @@
                 <div class="col-sm-8 mx-auto py-5">
                     <h1>Database CI/CD example</h1>
                     <p>
-                        This page is based on a simple <a href="https://palletsprojects.com/p/flask/">Python Flask</a>
-                        application using <a href="https://getbootstrap.com">Bootstrap CSS</a> for styling. It connects
-                        to an Oracle 23ai Free Database backend to increment the hit counter.
+                        This page is based on a simple <a target="_blank" href="https://palletsprojects.com/p/flask/">Python Flask</a>
+                        application using <a target="_blank" href="https://getbootstrap.com">Bootstrap CSS</a> for styling. It connects
+                        to an <a href="https://www.oracle.com/database/free/" target="_blank">Oracle 23ai Free</a>
+                        database to increment the hit counter.
                     </p>
 
                 </div>


### PR DESCRIPTION
Fix issue #13 by changing the comment.

This PR additionally fixes a problem in `index.html` whereas 

- a link to Oracle Database  23ai was missing
- links open in the same page rather than a new tab
